### PR TITLE
[ fix ] allow addon to load for non-cleanser classes

### DIFF
--- a/Rinse.lua
+++ b/Rinse.lua
@@ -868,12 +868,12 @@ function RinseFrame_OnEvent()
         RinseOptionsFrameShowHeader:SetChecked(RINSE_CONFIG.SHOW_HEADER)
         RinseOptionsFrameFlip:SetChecked(RINSE_CONFIG.FLIP)
         RinseOptionsFrameButtonsSlider:SetValue(RINSE_CONFIG.BUTTONS)
-        if Spells[playerClass].Poison then
+        if Spells[playerClass] and Spells[playerClass].Poison then
             EnableCheckBox(RinseOptionsFrameWyvernSting)
         else
             DisableCheckBox(RinseOptionsFrameWyvernSting)
         end
-        if Spells[playerClass].Disease then
+        if Spells[playerClass] and Spells[playerClass].Disease then
             EnableCheckBox(RinseOptionsFrameMutatingInjection)
         else
             DisableCheckBox(RinseOptionsFrameMutatingInjection)


### PR DESCRIPTION
Alternatively can add WARRIOR/ROGUE/HUNTER to the following as `{}`
```
local Spells = {}
Spells["PALADIN"] = { Magic = {"Cleanse"}, Poison = {"Cleanse", "Purify"}, Disease = {"Cleanse", "Purify"} }
Spells["DRUID"]   = { Curse = {"Remove Curse"}, Poison = {"Abolish Poison", "Cure Poison"} }
Spells["PRIEST"]  = { Magic = {"Dispel Magic"}, Disease = {"Abolish Disease", "Cure Disease"} }
Spells["SHAMAN"]  = { Poison = {"Cure Poison"}, Disease = {"Cure Disease"} }
Spells["MAGE"]    = { Curse = {"Remove Lesser Curse"} }
Spells["WARLOCK"] = { Magic = {"Devour Magic"} }
```
Wasn't sure which was the better choice